### PR TITLE
Added change to allow clippy::upper_case_acronyms.   Since the PACs g…

### DIFF
--- a/src/clock.rs
+++ b/src/clock.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::upper_case_acronyms)]
+
 #[cfg(feature = "atsam4e")]
 use crate::pac::{pmc, EFC, PMC};
 

--- a/src/static_memory_controller.rs
+++ b/src/static_memory_controller.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::upper_case_acronyms)]
+
 use {
     crate::clock::{Enabled, StaticMemoryControllerClock},
     crate::gpio::*,


### PR DESCRIPTION
…enerate these (and macros exist that consume those types exist), they're being allowed.