### PR TITLE
Added pub use on embedded_hal::watchdog traits so clients can use ena…

### DIFF
--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -1,5 +1,9 @@
 use crate::pac::WDT;
 use hal::watchdog;
+pub use hal::watchdog::{
+    WatchdogDisable,
+    WatchdogEnable,
+};
 
 pub struct Watchdog {
     wdt: WDT,

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -1,9 +1,6 @@
 use crate::pac::WDT;
 use hal::watchdog;
-pub use hal::watchdog::{
-    WatchdogDisable,
-    WatchdogEnable,
-};
+pub use hal::watchdog::{WatchdogDisable, WatchdogEnable};
 
 pub struct Watchdog {
     wdt: WDT,


### PR DESCRIPTION
…ble/disable on watchdog without having to "use" the embedded_hal.

I ran into this when disabling the new watchdog with the SAM4E BSP:

error[E0599]: no method named `disable` found for struct `sam4e_xplained_pro::atsam4_hal::watchdog::Watchdog` in the current scope
  --> examples/blinky.rs:68:36
   |
68 |     Watchdog::new(peripherals.WDT).disable();
   |                                    ^^^^^^^ method not found in `sam4e_xplained_pro::atsam4_hal::watchdog::Watchdog`
   |
   = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
   |
7  | use sam4e_xplained_pro::atsam4_hal::prelude::_embedded_hal_watchdog_WatchdogDisable;
   |
