### PR TITLE
Adding feature flag for USB clock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ version = "0.4.1"
 default = ["atsam4e16e"]
 unstable = []
 
+# Enable USB clock support
+usb = []
+
 # atsam4e
 atsam4e = []
 atsam4e16e = ["atsam4e", "atsam4e16e-pac", "atsam4e16e-pac/rt"]


### PR DESCRIPTION
- Depending on the MCU enable PLLB or not for USB clock
- Otherwise, for MCUs with only PLLA, down-configure to save current
  usage