### PR TITLE
Updating to -pac 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/atsam4-rs/atsam4-hal"
 [dependencies]
 cast = { version = "0.2.2", default-features = false }
 cortex-m = "0.7.3"
-cortex-m-rt = "0.6.13"
 defmt = "0.2"
 embedded-dma = "0.1.2"
 embedded-hal = { version = "0.2.6", features = ["unproven"] }
@@ -26,33 +25,33 @@ void = { version = "1.0.2", default-features = false }
 volatile = "0.4.1"
 
 # atsam4e
-atsam4e8c-pac = { version = "0.1.7", optional = true }
-atsam4e8e-pac = { version = "0.1.7", optional = true }
-atsam4e16c-pac = { version = "0.1.7", optional = true }
-atsam4e16e-pac = { version = "0.1.7", optional = true }
+atsam4e8c-pac = { version = "0.2.0", optional = true }
+atsam4e8e-pac = { version = "0.2.0", optional = true }
+atsam4e16c-pac = { version = "0.2.0", optional = true }
+atsam4e16e-pac = { version = "0.2.0", optional = true }
 
 # atsam4n
-atsam4n8a-pac = { version = "0.1.0", optional = true }
-atsam4n8b-pac = { version = "0.1.0", optional = true }
-atsam4n8c-pac = { version = "0.1.0", optional = true }
-atsam4n16b-pac = { version = "0.1.0", optional = true }
-atsam4n16c-pac = { version = "0.1.0", optional = true }
+atsam4n8a-pac = { version = "0.2.0", optional = true }
+atsam4n8b-pac = { version = "0.2.0", optional = true }
+atsam4n8c-pac = { version = "0.2.0", optional = true }
+atsam4n16b-pac = { version = "0.2.0", optional = true }
+atsam4n16c-pac = { version = "0.2.0", optional = true }
 
 # atsam4s
-atsam4s2a-pac = { version = "0.1.2", optional = true }
-atsam4s2b-pac = { version = "0.1.2", optional = true }
-atsam4s2c-pac = { version = "0.1.2", optional = true }
-atsam4s4a-pac = { version = "0.1.2", optional = true }
-atsam4s4b-pac = { version = "0.1.2", optional = true }
-atsam4s4c-pac = { version = "0.1.2", optional = true }
-atsam4s8b-pac = { version = "0.1.2", optional = true }
-atsam4s8c-pac = { version = "0.1.2", optional = true }
-atsam4sa16b-pac = { version = "0.1.2", optional = true }
-atsam4sa16c-pac = { version = "0.1.2", optional = true }
-atsam4sd16b-pac = { version = "0.1.2", optional = true }
-atsam4sd16c-pac = { version = "0.1.2", optional = true }
-atsam4sd32b-pac = { version = "0.1.2", optional = true }
-atsam4sd32c-pac = { version = "0.1.2", optional = true }
+atsam4s2a-pac = { version = "0.2.0", optional = true }
+atsam4s2b-pac = { version = "0.2.0", optional = true }
+atsam4s2c-pac = { version = "0.2.0", optional = true }
+atsam4s4a-pac = { version = "0.2.0", optional = true }
+atsam4s4b-pac = { version = "0.2.0", optional = true }
+atsam4s4c-pac = { version = "0.2.0", optional = true }
+atsam4s8b-pac = { version = "0.2.0", optional = true }
+atsam4s8c-pac = { version = "0.2.0", optional = true }
+atsam4sa16b-pac = { version = "0.2.0", optional = true }
+atsam4sa16c-pac = { version = "0.2.0", optional = true }
+atsam4sd16b-pac = { version = "0.2.0", optional = true }
+atsam4sd16c-pac = { version = "0.2.0", optional = true }
+atsam4sd32b-pac = { version = "0.2.0", optional = true }
+atsam4sd32c-pac = { version = "0.2.0", optional = true }
 
 [features]
 default = ["atsam4e16e"]

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -193,15 +193,17 @@ impl Adc {
          *
          * adc_init(ADC, sysclk_get_cpu_hz(), 20000000, ADC_STARTUP_TIME_5);
          */
-        // Reset the controller (simulates hardware reset)
-        adc.cr.write_with_zero(|w| w.swrst().set_bit());
+        unsafe {
+            // Reset the controller (simulates hardware reset)
+            adc.cr.write_with_zero(|w| w.swrst().set_bit());
 
-        // Reset mode register (set all fields to 0)
-        adc.mr.write_with_zero(|w| w);
+            // Reset mode register (set all fields to 0)
+            adc.mr.write_with_zero(|w| w);
 
-        // Reset PDC transfer
-        adc.ptcr
-            .write_with_zero(|w| w.rxtdis().set_bit().txtdis().set_bit());
+            // Reset PDC transfer
+            adc.ptcr
+                .write_with_zero(|w| w.rxtdis().set_bit().txtdis().set_bit());
+        }
 
         // Setup prescalar and startup time
         let prescaler = (clock.frequency().0 / (2 * Hertz(20000000).0) - 1) as u8;
@@ -485,7 +487,7 @@ impl Adc {
     /// Autocalibration
     /// Wait will block until autocalibration is complete
     pub fn autocalibration(&mut self, wait: bool) {
-        self.adc.cr.write_with_zero(|w| w.autocal().set_bit());
+        unsafe { self.adc.cr.write_with_zero(|w| w.autocal().set_bit()) };
 
         if wait {
             while !self.calibration_ready() {}
@@ -535,7 +537,7 @@ impl Adc {
     }
 
     fn start_conversion(&mut self) {
-        self.adc.cr.write_with_zero(|w| w.start().set_bit());
+        unsafe { self.adc.cr.write_with_zero(|w| w.start().set_bit()) };
     }
 
     /// Enables the ADC pin channel
@@ -543,49 +545,53 @@ impl Adc {
     /// This is needed to determine the various gain+offset settings used
     /// See Section in 42.6.12 in the ATSAM4S datasheet for more details
     pub fn enable_channel<PIN: Channel<ADC, ID = u8>>(&mut self, _pin: &mut PIN) {
-        match PIN::channel() {
-            0 => self.adc.cher.write_with_zero(|w| w.ch0().set_bit()),
-            1 => self.adc.cher.write_with_zero(|w| w.ch1().set_bit()),
-            2 => self.adc.cher.write_with_zero(|w| w.ch2().set_bit()),
-            3 => self.adc.cher.write_with_zero(|w| w.ch3().set_bit()),
-            4 => self.adc.cher.write_with_zero(|w| w.ch4().set_bit()),
-            5 => self.adc.cher.write_with_zero(|w| w.ch5().set_bit()),
-            6 => self.adc.cher.write_with_zero(|w| w.ch6().set_bit()),
-            7 => self.adc.cher.write_with_zero(|w| w.ch7().set_bit()),
-            8 => self.adc.cher.write_with_zero(|w| w.ch8().set_bit()),
-            9 => self.adc.cher.write_with_zero(|w| w.ch9().set_bit()),
-            10 => self.adc.cher.write_with_zero(|w| w.ch10().set_bit()),
-            11 => self.adc.cher.write_with_zero(|w| w.ch11().set_bit()),
-            12 => self.adc.cher.write_with_zero(|w| w.ch12().set_bit()),
-            13 => self.adc.cher.write_with_zero(|w| w.ch13().set_bit()),
-            14 => self.adc.cher.write_with_zero(|w| w.ch14().set_bit()),
-            15 => self.adc.cher.write_with_zero(|w| w.ch15().set_bit()),
-            _ => {
-                panic!("Invalid channel: {}", PIN::channel());
+        unsafe {
+            match PIN::channel() {
+                0 => self.adc.cher.write_with_zero(|w| w.ch0().set_bit()),
+                1 => self.adc.cher.write_with_zero(|w| w.ch1().set_bit()),
+                2 => self.adc.cher.write_with_zero(|w| w.ch2().set_bit()),
+                3 => self.adc.cher.write_with_zero(|w| w.ch3().set_bit()),
+                4 => self.adc.cher.write_with_zero(|w| w.ch4().set_bit()),
+                5 => self.adc.cher.write_with_zero(|w| w.ch5().set_bit()),
+                6 => self.adc.cher.write_with_zero(|w| w.ch6().set_bit()),
+                7 => self.adc.cher.write_with_zero(|w| w.ch7().set_bit()),
+                8 => self.adc.cher.write_with_zero(|w| w.ch8().set_bit()),
+                9 => self.adc.cher.write_with_zero(|w| w.ch9().set_bit()),
+                10 => self.adc.cher.write_with_zero(|w| w.ch10().set_bit()),
+                11 => self.adc.cher.write_with_zero(|w| w.ch11().set_bit()),
+                12 => self.adc.cher.write_with_zero(|w| w.ch12().set_bit()),
+                13 => self.adc.cher.write_with_zero(|w| w.ch13().set_bit()),
+                14 => self.adc.cher.write_with_zero(|w| w.ch14().set_bit()),
+                15 => self.adc.cher.write_with_zero(|w| w.ch15().set_bit()),
+                _ => {
+                    panic!("Invalid channel: {}", PIN::channel());
+                }
             }
         }
     }
 
     pub fn disable_channel<PIN: Channel<ADC, ID = u8>>(&mut self, _pin: &mut PIN) {
-        match PIN::channel() {
-            0 => self.adc.chdr.write_with_zero(|w| w.ch0().set_bit()),
-            1 => self.adc.chdr.write_with_zero(|w| w.ch1().set_bit()),
-            2 => self.adc.chdr.write_with_zero(|w| w.ch2().set_bit()),
-            3 => self.adc.chdr.write_with_zero(|w| w.ch3().set_bit()),
-            4 => self.adc.chdr.write_with_zero(|w| w.ch4().set_bit()),
-            5 => self.adc.chdr.write_with_zero(|w| w.ch5().set_bit()),
-            6 => self.adc.chdr.write_with_zero(|w| w.ch6().set_bit()),
-            7 => self.adc.chdr.write_with_zero(|w| w.ch7().set_bit()),
-            8 => self.adc.chdr.write_with_zero(|w| w.ch8().set_bit()),
-            9 => self.adc.chdr.write_with_zero(|w| w.ch9().set_bit()),
-            10 => self.adc.chdr.write_with_zero(|w| w.ch10().set_bit()),
-            11 => self.adc.chdr.write_with_zero(|w| w.ch11().set_bit()),
-            12 => self.adc.chdr.write_with_zero(|w| w.ch12().set_bit()),
-            13 => self.adc.chdr.write_with_zero(|w| w.ch13().set_bit()),
-            14 => self.adc.chdr.write_with_zero(|w| w.ch14().set_bit()),
-            15 => self.adc.chdr.write_with_zero(|w| w.ch15().set_bit()),
-            _ => {
-                panic!("Invalid channel: {}", PIN::channel());
+        unsafe {
+            match PIN::channel() {
+                0 => self.adc.chdr.write_with_zero(|w| w.ch0().set_bit()),
+                1 => self.adc.chdr.write_with_zero(|w| w.ch1().set_bit()),
+                2 => self.adc.chdr.write_with_zero(|w| w.ch2().set_bit()),
+                3 => self.adc.chdr.write_with_zero(|w| w.ch3().set_bit()),
+                4 => self.adc.chdr.write_with_zero(|w| w.ch4().set_bit()),
+                5 => self.adc.chdr.write_with_zero(|w| w.ch5().set_bit()),
+                6 => self.adc.chdr.write_with_zero(|w| w.ch6().set_bit()),
+                7 => self.adc.chdr.write_with_zero(|w| w.ch7().set_bit()),
+                8 => self.adc.chdr.write_with_zero(|w| w.ch8().set_bit()),
+                9 => self.adc.chdr.write_with_zero(|w| w.ch9().set_bit()),
+                10 => self.adc.chdr.write_with_zero(|w| w.ch10().set_bit()),
+                11 => self.adc.chdr.write_with_zero(|w| w.ch11().set_bit()),
+                12 => self.adc.chdr.write_with_zero(|w| w.ch12().set_bit()),
+                13 => self.adc.chdr.write_with_zero(|w| w.ch13().set_bit()),
+                14 => self.adc.chdr.write_with_zero(|w| w.ch14().set_bit()),
+                15 => self.adc.chdr.write_with_zero(|w| w.ch15().set_bit()),
+                _ => {
+                    panic!("Invalid channel: {}", PIN::channel());
+                }
             }
         }
     }
@@ -595,50 +601,54 @@ impl Adc {
     /// has the tendency to lose samples. Instead each channel interrupt is used instead
     /// so that no samples are lost.
     fn enable_interrupts<PIN: Channel<ADC, ID = u8>>(&mut self, _pin: &mut PIN) {
-        match PIN::channel() {
-            0 => self.adc.ier.write_with_zero(|w| w.eoc0().set_bit()),
-            1 => self.adc.ier.write_with_zero(|w| w.eoc1().set_bit()),
-            2 => self.adc.ier.write_with_zero(|w| w.eoc2().set_bit()),
-            3 => self.adc.ier.write_with_zero(|w| w.eoc3().set_bit()),
-            4 => self.adc.ier.write_with_zero(|w| w.eoc4().set_bit()),
-            5 => self.adc.ier.write_with_zero(|w| w.eoc5().set_bit()),
-            6 => self.adc.ier.write_with_zero(|w| w.eoc6().set_bit()),
-            7 => self.adc.ier.write_with_zero(|w| w.eoc7().set_bit()),
-            8 => self.adc.ier.write_with_zero(|w| w.eoc8().set_bit()),
-            9 => self.adc.ier.write_with_zero(|w| w.eoc9().set_bit()),
-            10 => self.adc.ier.write_with_zero(|w| w.eoc10().set_bit()),
-            11 => self.adc.ier.write_with_zero(|w| w.eoc11().set_bit()),
-            12 => self.adc.ier.write_with_zero(|w| w.eoc12().set_bit()),
-            13 => self.adc.ier.write_with_zero(|w| w.eoc13().set_bit()),
-            14 => self.adc.ier.write_with_zero(|w| w.eoc14().set_bit()),
-            15 => self.adc.ier.write_with_zero(|w| w.eoc15().set_bit()),
-            _ => {
-                panic!("Invalid channel: {}", PIN::channel());
+        unsafe {
+            match PIN::channel() {
+                0 => self.adc.ier.write_with_zero(|w| w.eoc0().set_bit()),
+                1 => self.adc.ier.write_with_zero(|w| w.eoc1().set_bit()),
+                2 => self.adc.ier.write_with_zero(|w| w.eoc2().set_bit()),
+                3 => self.adc.ier.write_with_zero(|w| w.eoc3().set_bit()),
+                4 => self.adc.ier.write_with_zero(|w| w.eoc4().set_bit()),
+                5 => self.adc.ier.write_with_zero(|w| w.eoc5().set_bit()),
+                6 => self.adc.ier.write_with_zero(|w| w.eoc6().set_bit()),
+                7 => self.adc.ier.write_with_zero(|w| w.eoc7().set_bit()),
+                8 => self.adc.ier.write_with_zero(|w| w.eoc8().set_bit()),
+                9 => self.adc.ier.write_with_zero(|w| w.eoc9().set_bit()),
+                10 => self.adc.ier.write_with_zero(|w| w.eoc10().set_bit()),
+                11 => self.adc.ier.write_with_zero(|w| w.eoc11().set_bit()),
+                12 => self.adc.ier.write_with_zero(|w| w.eoc12().set_bit()),
+                13 => self.adc.ier.write_with_zero(|w| w.eoc13().set_bit()),
+                14 => self.adc.ier.write_with_zero(|w| w.eoc14().set_bit()),
+                15 => self.adc.ier.write_with_zero(|w| w.eoc15().set_bit()),
+                _ => {
+                    panic!("Invalid channel: {}", PIN::channel());
+                }
             }
         }
     }
 
     /// Disables the interrupts.
     fn disable_interrupts<PIN: Channel<ADC, ID = u8>>(&mut self, _pin: &mut PIN) {
-        match PIN::channel() {
-            0 => self.adc.idr.write_with_zero(|w| w.eoc0().set_bit()),
-            1 => self.adc.idr.write_with_zero(|w| w.eoc1().set_bit()),
-            2 => self.adc.idr.write_with_zero(|w| w.eoc2().set_bit()),
-            3 => self.adc.idr.write_with_zero(|w| w.eoc3().set_bit()),
-            4 => self.adc.idr.write_with_zero(|w| w.eoc4().set_bit()),
-            5 => self.adc.idr.write_with_zero(|w| w.eoc5().set_bit()),
-            6 => self.adc.idr.write_with_zero(|w| w.eoc6().set_bit()),
-            7 => self.adc.idr.write_with_zero(|w| w.eoc7().set_bit()),
-            8 => self.adc.idr.write_with_zero(|w| w.eoc8().set_bit()),
-            9 => self.adc.idr.write_with_zero(|w| w.eoc9().set_bit()),
-            10 => self.adc.idr.write_with_zero(|w| w.eoc10().set_bit()),
-            11 => self.adc.idr.write_with_zero(|w| w.eoc11().set_bit()),
-            12 => self.adc.idr.write_with_zero(|w| w.eoc12().set_bit()),
-            13 => self.adc.idr.write_with_zero(|w| w.eoc13().set_bit()),
-            14 => self.adc.idr.write_with_zero(|w| w.eoc14().set_bit()),
-            15 => self.adc.idr.write_with_zero(|w| w.eoc15().set_bit()),
-            _ => {
-                panic!("Invalid channel: {}", PIN::channel());
+        unsafe {
+            match PIN::channel() {
+                0 => self.adc.idr.write_with_zero(|w| w.eoc0().set_bit()),
+                1 => self.adc.idr.write_with_zero(|w| w.eoc1().set_bit()),
+                2 => self.adc.idr.write_with_zero(|w| w.eoc2().set_bit()),
+                3 => self.adc.idr.write_with_zero(|w| w.eoc3().set_bit()),
+                4 => self.adc.idr.write_with_zero(|w| w.eoc4().set_bit()),
+                5 => self.adc.idr.write_with_zero(|w| w.eoc5().set_bit()),
+                6 => self.adc.idr.write_with_zero(|w| w.eoc6().set_bit()),
+                7 => self.adc.idr.write_with_zero(|w| w.eoc7().set_bit()),
+                8 => self.adc.idr.write_with_zero(|w| w.eoc8().set_bit()),
+                9 => self.adc.idr.write_with_zero(|w| w.eoc9().set_bit()),
+                10 => self.adc.idr.write_with_zero(|w| w.eoc10().set_bit()),
+                11 => self.adc.idr.write_with_zero(|w| w.eoc11().set_bit()),
+                12 => self.adc.idr.write_with_zero(|w| w.eoc12().set_bit()),
+                13 => self.adc.idr.write_with_zero(|w| w.eoc13().set_bit()),
+                14 => self.adc.idr.write_with_zero(|w| w.eoc14().set_bit()),
+                15 => self.adc.idr.write_with_zero(|w| w.eoc15().set_bit()),
+                _ => {
+                    panic!("Invalid channel: {}", PIN::channel());
+                }
             }
         }
     }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -50,15 +50,19 @@ fn setup_slow_clock(supc: &SUPC, slow_clock: SlowClock) -> Hertz {
         SlowClock::RcOscillator32Khz => {}
         SlowClock::Crystal32Khz => {
             // Enable crystal oscillator (also disables Slow RC Oscillator)
-            supc.cr
-                .write_with_zero(|w| w.key().passwd().xtalsel().crystal_sel());
+            unsafe {
+                supc.cr
+                    .write_with_zero(|w| w.key().passwd().xtalsel().crystal_sel());
+            }
         }
         SlowClock::OscillatorBypass32Khz => {
             // Enable bypass mode
             supc.mr.modify(|_, w| w.key().passwd().oscbypass().bypass());
             // Enable crystal oscillator (also disables Slow RC Oscillator)
-            supc.cr
-                .write_with_zero(|w| w.key().passwd().xtalsel().crystal_sel());
+            unsafe {
+                supc.cr
+                    .write_with_zero(|w| w.key().passwd().xtalsel().crystal_sel());
+            }
         }
     }
     // 32.768 kHz
@@ -594,11 +598,11 @@ macro_rules! peripheral_clocks {
                 pub fn into_enabled_clock(mut self) -> $PeripheralType<Enabled> {
                     if $i <= 31 {
                         let shift = $i;
-                        self.pcer0().write_with_zero(|w| unsafe { w.bits(1 << shift) });
+                        unsafe {self.pcer0().write_with_zero(|w| w.bits(1 << shift) )};
                     }
                     else {
                         let shift = ($i - 32);
-                        self.pcer1().write_with_zero(|w| unsafe { w.bits(1 << shift) });
+                        unsafe {self.pcer1().write_with_zero(|w| w.bits(1 << shift) )};
                     }
                     $PeripheralType { _state: PhantomData }
                 }
@@ -606,7 +610,7 @@ macro_rules! peripheral_clocks {
                 #[cfg(feature = "atsam4n")]
                 pub fn into_enabled_clock(mut self) -> $PeripheralType<Enabled> {
                     let shift = $i;
-                    self.pcer0().write_with_zero(|w| unsafe { w.bits(1 << shift) });
+                    unsafe {self.pcer0().write_with_zero(|w| w.bits(1 << shift) )};
                     $PeripheralType { _state: PhantomData }
                 }
 
@@ -614,11 +618,11 @@ macro_rules! peripheral_clocks {
                 pub fn into_disabled_clock(mut self) -> $PeripheralType<Disabled> {
                     if $i <= 31 {
                         let shift = $i;
-                        self.pcdr0().write_with_zero(|w| unsafe { w.bits(1 << shift) });
+                        unsafe {self.pcdr0().write_with_zero(|w| w.bits(1 << shift) )};
                     }
                     else {
                         let shift = ($i - 32);
-                        self.pcdr1().write_with_zero(|w| unsafe { w.bits(1 << shift) });
+                        unsafe {self.pcdr1().write_with_zero(|w| w.bits(1 << shift) )};
                     }
                     $PeripheralType { _state: PhantomData }
                 }
@@ -626,7 +630,7 @@ macro_rules! peripheral_clocks {
                 #[cfg(feature = "atsam4n")]
                 pub fn into_disabled_clock(mut self) -> $PeripheralType<Disabled> {
                     let shift = $i;
-                    self.pcdr0().write_with_zero(|w| unsafe { w.bits(1 << shift) });
+                    unsafe {self.pcdr0().write_with_zero(|w| w.bits(1 << shift) )};
                     $PeripheralType { _state: PhantomData }
                 }
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -255,17 +255,20 @@ macro_rules! pin_sysio {
     ) => {
         impl<MODE> $PinType<MODE> {
             fn prepare_pin_for_function_use(&mut self) {
-                self.pudr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable Pullup
-                self.ppddr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable Pulldown
-                self.mddr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable Multi-drive (open drain)
-                self.ifscdr()
-                    .write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable Glitch filter (Debounce)
+                unsafe {
+                    self.pudr().write_with_zero(|w| w.bits(1 << $i)); // Disable Pullup
+                    self.ppddr().write_with_zero(|w| w.bits(1 << $i)); // Disable Pulldown
+                    self.mddr().write_with_zero(|w| w.bits(1 << $i)); // Disable Multi-drive (open drain)
+                    self.ifscdr().write_with_zero(|w| w.bits(1 << $i)); // Disable Glitch filter (Debounce)
+                }
             }
 
             fn prepare_pin_for_input_use(&mut self) {
                 self.disable_pin_interrupt(); // Disable interrupt
-                self.mddr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable open-drain/multi-drive
-                self.odr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable output mode
+                unsafe {
+                    self.mddr().write_with_zero(|w| w.bits(1 << $i)); // Disable open-drain/multi-drive
+                    self.odr().write_with_zero(|w| w.bits(1 << $i)); // Disable output mode
+                }
             }
 
             pub fn into_peripheral_function_a(mut self, _matrix: &MATRIX) -> $PinType<PfA> {
@@ -314,8 +317,10 @@ macro_rules! pin_sysio {
 
             pub fn into_floating_input(mut self, _matrix: &MATRIX) -> $PinType<Input<Floating>> {
                 self.prepare_pin_for_input_use();
-                self.pudr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable pull-up
-                self.ppddr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable pull-down
+                unsafe {
+                    self.pudr().write_with_zero(|w| w.bits(1 << $i)); // Disable pull-up
+                    self.ppddr().write_with_zero(|w| w.bits(1 << $i)); // Disable pull-down
+                }
                 self.enable_pin();
 
                 $PinType { _mode: PhantomData }
@@ -323,8 +328,10 @@ macro_rules! pin_sysio {
 
             pub fn into_pull_down_input(mut self, _matrix: &MATRIX) -> $PinType<Input<PullDown>> {
                 self.prepare_pin_for_input_use();
-                self.pudr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable pull-up (this must happen first when enabling pull-down resistors)
-                self.ppder().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Enable pull-down
+                unsafe {
+                    self.pudr().write_with_zero(|w| w.bits(1 << $i)); // Disable pull-up (this must happen first when enabling pull-down resistors)
+                    self.ppder().write_with_zero(|w| w.bits(1 << $i)); // Enable pull-down
+                }
                 self.enable_pin();
 
                 $PinType { _mode: PhantomData }
@@ -332,8 +339,10 @@ macro_rules! pin_sysio {
 
             pub fn into_pull_up_input(mut self, _matrix: &MATRIX) -> $PinType<Input<PullUp>> {
                 self.prepare_pin_for_input_use();
-                self.ppddr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable pull-down
-                self.puer().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Enable pull-up
+                unsafe {
+                    self.ppddr().write_with_zero(|w| w.bits(1 << $i)); // Disable pull-down
+                    self.puer().write_with_zero(|w| w.bits(1 << $i)); // Enable pull-up
+                }
                 self.enable_pin();
 
                 $PinType { _mode: PhantomData }
@@ -345,8 +354,10 @@ macro_rules! pin_sysio {
                 _matrix: &MATRIX,
             ) -> $PinType<Output<OpenDrain>> {
                 self.disable_pin_interrupt();
-                self.mder().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Enable open-drain/multi-drive
-                self.oer().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Enable output mode
+                unsafe {
+                    self.mder().write_with_zero(|w| w.bits(1 << $i)); // Enable open-drain/multi-drive
+                    self.oer().write_with_zero(|w| w.bits(1 << $i)); // Enable output mode
+                }
                 self.enable_pin(); // Enable pio mode (disables peripheral control of pin)
 
                 $PinType { _mode: PhantomData }
@@ -355,9 +366,11 @@ macro_rules! pin_sysio {
             /// Configures the pin to operate as a push-pull output
             pub fn into_push_pull_output(mut self, _matrix: &MATRIX) -> $PinType<Output<PushPull>> {
                 self.disable_pin_interrupt();
-                self.mddr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable open-drain/multi-drive
-                self.oer().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Enable output mode
-                self.per().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Enable pio mode (disables peripheral control of pin)
+                unsafe {
+                    self.mddr().write_with_zero(|w| w.bits(1 << $i)); // Disable open-drain/multi-drive
+                    self.oer().write_with_zero(|w| w.bits(1 << $i)); // Enable output mode
+                    self.per().write_with_zero(|w| w.bits(1 << $i)); // Enable pio mode (disables peripheral control of pin)
+                }
 
                 $PinType { _mode: PhantomData }
             }
@@ -385,17 +398,20 @@ macro_rules! pin_sysio {
             }
 
             fn prepare_pin_for_function_use(&mut self) {
-                self.pudr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable Pullup
-                self.ppddr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable Pulldown
-                self.mddr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable Multi-drive (open drain)
-                self.ifscdr()
-                    .write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable Glitch filter (Debounce)
+                unsafe {
+                    self.pudr().write_with_zero(|w| w.bits(1 << $i)); // Disable Pullup
+                    self.ppddr().write_with_zero(|w| w.bits(1 << $i)); // Disable Pulldown
+                    self.mddr().write_with_zero(|w| w.bits(1 << $i)); // Disable Multi-drive (open drain)
+                    self.ifscdr().write_with_zero(|w| w.bits(1 << $i)); // Disable Glitch filter (Debounce)
+                }
             }
 
             fn prepare_pin_for_input_use(&mut self) {
                 self.disable_pin_interrupt(); // Disable interrupt
-                self.mddr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable open-drain/multi-drive
-                self.odr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable output mode
+                unsafe {
+                    self.mddr().write_with_zero(|w| w.bits(1 << $i)); // Disable open-drain/multi-drive
+                    self.odr().write_with_zero(|w| w.bits(1 << $i)); // Disable output mode
+                }
             }
 
             pub fn into_peripheral_function_a(mut self, matrix: &MATRIX) -> $PinType<PfA> {
@@ -449,8 +465,10 @@ macro_rules! pin_sysio {
             pub fn into_floating_input(mut self, matrix: &MATRIX) -> $PinType<Input<Floating>> {
                 self.prepare_pin_for_input_use();
                 self.disable_system_function(matrix);
-                self.pudr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable pull-up
-                self.ppddr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable pull-down
+                unsafe {
+                    self.pudr().write_with_zero(|w| w.bits(1 << $i)); // Disable pull-up
+                    self.ppddr().write_with_zero(|w| w.bits(1 << $i)); // Disable pull-down
+                }
                 self.enable_pin();
 
                 $PinType { _mode: PhantomData }
@@ -459,8 +477,10 @@ macro_rules! pin_sysio {
             pub fn into_pull_down_input(mut self, matrix: &MATRIX) -> $PinType<Input<PullDown>> {
                 self.prepare_pin_for_input_use();
                 self.disable_system_function(matrix);
-                self.pudr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable pull-up (this must happen first when enabling pull-down resistors)
-                self.ppder().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Enable pull-down
+                unsafe {
+                    self.pudr().write_with_zero(|w| w.bits(1 << $i)); // Disable pull-up (this must happen first when enabling pull-down resistors)
+                    self.ppder().write_with_zero(|w| w.bits(1 << $i)); // Enable pull-down
+                }
                 self.enable_pin();
 
                 $PinType { _mode: PhantomData }
@@ -469,8 +489,10 @@ macro_rules! pin_sysio {
             pub fn into_pull_up_input(mut self, matrix: &MATRIX) -> $PinType<Input<PullUp>> {
                 self.prepare_pin_for_input_use();
                 self.disable_system_function(matrix);
-                self.ppddr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable pull-down
-                self.puer().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Enable pull-up
+                unsafe {
+                    self.ppddr().write_with_zero(|w| w.bits(1 << $i)); // Disable pull-down
+                    self.puer().write_with_zero(|w| w.bits(1 << $i)); // Enable pull-up
+                }
                 self.enable_pin();
 
                 $PinType { _mode: PhantomData }
@@ -483,8 +505,10 @@ macro_rules! pin_sysio {
             ) -> $PinType<Output<OpenDrain>> {
                 self.disable_pin_interrupt();
                 self.disable_system_function(matrix);
-                self.mder().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Enable open-drain/multi-drive
-                self.oer().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Enable output mode
+                unsafe {
+                    self.mder().write_with_zero(|w| w.bits(1 << $i)); // Enable open-drain/multi-drive
+                    self.oer().write_with_zero(|w| w.bits(1 << $i)); // Enable output mode
+                }
                 self.enable_pin(); // Enable pio mode (disables peripheral control of pin)
 
                 $PinType { _mode: PhantomData }
@@ -494,9 +518,11 @@ macro_rules! pin_sysio {
             pub fn into_push_pull_output(mut self, matrix: &MATRIX) -> $PinType<Output<PushPull>> {
                 self.disable_pin_interrupt();
                 self.disable_system_function(matrix);
-                self.mddr().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Disable open-drain/multi-drive
-                self.oer().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Enable output mode
-                self.per().write_with_zero(|w| unsafe { w.bits(1 << $i) }); // Enable pio mode (disables peripheral control of pin)
+                unsafe {
+                    self.mddr().write_with_zero(|w| w.bits(1 << $i)); // Disable open-drain/multi-drive
+                    self.oer().write_with_zero(|w| w.bits(1 << $i)); // Enable output mode
+                    self.per().write_with_zero(|w| w.bits(1 << $i)); // Enable pio mode (disables peripheral control of pin)
+                }
 
                 $PinType { _mode: PhantomData }
             }
@@ -594,19 +620,19 @@ macro_rules! pin {
             }
 
             fn enable_pin(&mut self) {
-                self.per().write_with_zero(|w| unsafe { w.bits(1 << $i) });
+                unsafe { self.per().write_with_zero(|w| w.bits(1 << $i)) };
             }
 
             fn disable_pin(&mut self) {
-                self.pdr().write_with_zero(|w| unsafe { w.bits(1 << $i) });
+                unsafe { self.pdr().write_with_zero(|w| w.bits(1 << $i)) };
             }
 
             fn _enable_pin_interrupt(&mut self) {
-                self._ier().write_with_zero(|w| unsafe { w.bits(1 << $i) });
+                unsafe { self._ier().write_with_zero(|w| w.bits(1 << $i)) };
             }
 
             fn disable_pin_interrupt(&mut self) {
-                self.idr().write_with_zero(|w| unsafe { w.bits(1 << $i) });
+                unsafe { self.idr().write_with_zero(|w| w.bits(1 << $i)) };
             }
         }
 
@@ -626,12 +652,12 @@ macro_rules! pin {
             type Error = Infallible;
 
             fn set_high(&mut self) -> Result<(), Self::Error> {
-                self.sodr().write_with_zero(|w| unsafe { w.bits(1 << $i) });
+                unsafe { self.sodr().write_with_zero(|w| w.bits(1 << $i)) };
                 Ok(())
             }
 
             fn set_low(&mut self) -> Result<(), Self::Error> {
-                self.codr().write_with_zero(|w| unsafe { w.bits(1 << $i) });
+                unsafe { self.codr().write_with_zero(|w| w.bits(1 << $i)) };
                 Ok(())
             }
         }

--- a/src/pdc.rs
+++ b/src/pdc.rs
@@ -193,12 +193,12 @@ macro_rules! pdc_rx {
 
             /// Starts the PDC transfer
             pub fn start_rx_pdc(&mut self) {
-                self.$periph.ptcr.write_with_zero(|w| w.rxten().set_bit());
+                unsafe { self.$periph.ptcr.write_with_zero(|w| w.rxten().set_bit()) };
             }
 
             /// Stops the PDC transfer
             pub fn stop_rx_pdc(&mut self) {
-                self.$periph.ptcr.write_with_zero(|w| w.rxtdis().set_bit());
+                unsafe { self.$periph.ptcr.write_with_zero(|w| w.rxtdis().set_bit()) };
             }
 
             /// Returns `true` if the PDC is active and may be receiving data
@@ -215,23 +215,23 @@ macro_rules! pdc_rx {
             /// Enable ENDRX (End of Receive) interrupt
             /// Triggered when RCR reaches 0
             pub fn enable_endrx_interrupt(&mut self) {
-                self.$periph.ier.write_with_zero(|w| w.endrx().set_bit());
+                unsafe { self.$periph.ier.write_with_zero(|w| w.endrx().set_bit()) };
             }
 
             /// Disable ENDRX (End of Receive) interrupt
             pub fn disable_endrx_interrupt(&mut self) {
-                self.$periph.idr.write_with_zero(|w| w.endrx().set_bit());
+                unsafe { self.$periph.idr.write_with_zero(|w| w.endrx().set_bit()) };
             }
 
             /// Enable RXBUFF (Receive Buffer Full) interrupt
             /// Triggered when RCR and RNCR reach 0
             pub fn enable_rxbuff_interrupt(&mut self) {
-                self.$periph.ier.write_with_zero(|w| w.rxbuff().set_bit());
+                unsafe { self.$periph.ier.write_with_zero(|w| w.rxbuff().set_bit()) };
             }
 
             /// Disable RXBUFF (Receive Buffer Full) interrupt
             pub fn disable_rxbuff_interrupt(&mut self) {
-                self.$periph.idr.write_with_zero(|w| w.rxbuff().set_bit());
+                unsafe { self.$periph.idr.write_with_zero(|w| w.rxbuff().set_bit()) };
             }
         }
     };

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -115,15 +115,15 @@ macro_rules! uarts {
                     }
 
                     fn reset_and_disable(uart: &mut $UART) {
-                        uart.cr.write_with_zero(|w| {
+                        unsafe { uart.cr.write_with_zero(|w| {
                             w.rstrx().set_bit().rsttx().set_bit().rxdis().set_bit().txdis().set_bit()
-                        });
+                        })};
                     }
 
                     fn enable(uart: &mut $UART) {
-                        uart.cr.write_with_zero(|w| {
+                        unsafe {uart.cr.write_with_zero(|w| {
                             w.rxen().set_bit().txen().set_bit()
-                        });
+                        })};
                     }
 
                     pub fn write_string_blocking(&mut self, data: &str) {
@@ -170,7 +170,7 @@ macro_rules! uarts {
 
                         // omitted: checks for other errors
                         if isr.txrdy().bit_is_set() {
-                            Ok(self.uart.thr.write_with_zero(|w| unsafe { w.txchr().bits(byte) }))
+                            unsafe { Ok(self.uart.thr.write_with_zero(|w| w.txchr().bits(byte) )) }
                         } else {
                             // No data available yet
                             Err(nb::Error::WouldBlock)

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -89,6 +89,7 @@ impl TimerCounter<$TC, $clock<Enabled>>
     /// while !tcc1.wait().is_ok() {}
     /// ```
     pub fn new(tc: $TC, clock: $clock<Enabled>) -> Self {
+        unsafe {
         // Disable write-protect mode
         tc.wpmr.write_with_zero(|w| w.wpkey().passwd().wpen().clear_bit());
 
@@ -96,6 +97,7 @@ impl TimerCounter<$TC, $clock<Enabled>>
         tc.ccr0.write_with_zero(|w| w.clkdis().set_bit());
         tc.ccr1.write_with_zero(|w| w.clkdis().set_bit());
         tc.ccr2.write_with_zero(|w| w.clkdis().set_bit());
+        }
 
         Self {
             clock,
@@ -135,9 +137,9 @@ impl<const CH: usize> TimerCounterChannel<$TC, CH> {
     ///       e.g. TC:1 CH:2 => 1 * 3 + 2 = 5
     pub fn enable_interrupt(&mut self) {
         match CH {
-            0 => $TC::borrow_unchecked(|tc| tc.ier0.write_with_zero(|w| w.cpcs().set_bit())),
-            1 => $TC::borrow_unchecked(|tc| tc.ier1.write_with_zero(|w| w.cpcs().set_bit())),
-            2 => $TC::borrow_unchecked(|tc| tc.ier2.write_with_zero(|w| w.cpcs().set_bit())),
+            0 => $TC::borrow_unchecked(|tc| unsafe { tc.ier0.write_with_zero(|w| w.cpcs().set_bit())}),
+            1 => $TC::borrow_unchecked(|tc| unsafe { tc.ier1.write_with_zero(|w| w.cpcs().set_bit())}),
+            2 => $TC::borrow_unchecked(|tc| unsafe { tc.ier2.write_with_zero(|w| w.cpcs().set_bit())}),
             _ => panic!("Invalid TimerCounterChannel: {}", CH),
         }
     }
@@ -145,9 +147,9 @@ impl<const CH: usize> TimerCounterChannel<$TC, CH> {
     /// Disables the interrupt for this TimerCounterChannel
     pub fn disable_interrupt(&mut self) {
         match CH {
-            0 => $TC::borrow_unchecked(|tc| tc.idr0.write_with_zero(|w| w.cpcs().set_bit())),
-            1 => $TC::borrow_unchecked(|tc| tc.idr1.write_with_zero(|w| w.cpcs().set_bit())),
-            2 => $TC::borrow_unchecked(|tc| tc.idr2.write_with_zero(|w| w.cpcs().set_bit())),
+            0 => $TC::borrow_unchecked(|tc| unsafe { tc.idr0.write_with_zero(|w| w.cpcs().set_bit())}),
+            1 => $TC::borrow_unchecked(|tc| unsafe { tc.idr1.write_with_zero(|w| w.cpcs().set_bit())}),
+            2 => $TC::borrow_unchecked(|tc| unsafe { tc.idr2.write_with_zero(|w| w.cpcs().set_bit())}),
             _ => panic!("Invalid TimerCounterChannel: {}", CH),
         }
     }
@@ -215,9 +217,9 @@ impl<const CH: usize> CountDown for TimerCounterChannel<$TC, CH> {
 
         // Setup count-down value
         match CH {
-            0 => $TC::borrow_unchecked(|tc| tc.rc0.write_with_zero(|w| unsafe { w.rc().bits(cycles) })),
-            1 => $TC::borrow_unchecked(|tc| tc.rc1.write_with_zero(|w| unsafe { w.rc().bits(cycles) })),
-            2 => $TC::borrow_unchecked(|tc| tc.rc2.write_with_zero(|w| unsafe { w.rc().bits(cycles) })),
+            0 => $TC::borrow_unchecked(|tc| unsafe { tc.rc0.write_with_zero(|w| w.rc().bits(cycles) )}),
+            1 => $TC::borrow_unchecked(|tc| unsafe { tc.rc1.write_with_zero(|w| w.rc().bits(cycles) )}),
+            2 => $TC::borrow_unchecked(|tc| unsafe { tc.rc2.write_with_zero(|w| w.rc().bits(cycles) )}),
             _ => panic!("Invalid TimerCounterChannel: {}", CH),
         }
 
@@ -226,9 +228,9 @@ impl<const CH: usize> CountDown for TimerCounterChannel<$TC, CH> {
 
         // Enable timer and start using software trigger
         match CH {
-            0 => $TC::borrow_unchecked(|tc| tc.ccr0.write_with_zero(|w| w.clken().set_bit().swtrg().set_bit())),
-            1 => $TC::borrow_unchecked(|tc| tc.ccr1.write_with_zero(|w| w.clken().set_bit().swtrg().set_bit())),
-            2 => $TC::borrow_unchecked(|tc| tc.ccr2.write_with_zero(|w| w.clken().set_bit().swtrg().set_bit())),
+            0 => $TC::borrow_unchecked(|tc| unsafe { tc.ccr0.write_with_zero(|w| w.clken().set_bit().swtrg().set_bit())}),
+            1 => $TC::borrow_unchecked(|tc| unsafe { tc.ccr1.write_with_zero(|w| w.clken().set_bit().swtrg().set_bit())}),
+            2 => $TC::borrow_unchecked(|tc| unsafe { tc.ccr2.write_with_zero(|w| w.clken().set_bit().swtrg().set_bit())}),
             _ => panic!("Invalid TimerCounterChannel: {}", CH),
         }
     }

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -16,9 +16,11 @@ impl watchdog::Watchdog for Watchdog {
     /// Feeds an existing watchdog to ensure the processor isn't reset.
     /// Sometimes commonly referred to as "kicking" or "refreshing".
     fn feed(&mut self) {
-        self.wdt
-            .cr
-            .write_with_zero(|w| w.key().passwd().wdrstt().set_bit());
+        unsafe {
+            self.wdt
+                .cr
+                .write_with_zero(|w| w.key().passwd().wdrstt().set_bit());
+        }
     }
 }
 


### PR DESCRIPTION
- write_with_zero has changed to be unsafe
  See https://github.com/rust-embedded/svd2rust/blob/master/CHANGELOG.md#changed-2
- csr_mut() to csr()
- Removed cortex-m-rt (not necessary, handled by -pac crates)