### PR TITLE
Updating dependencies and add DwtTimer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "atsam4-hal"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["John W. Terrell <john@coolpeoplenetworks.com>", "Jacob Alexander <haata@kiibohd.com>"]
-edition = "2018"
+edition = "2021"
 description = "HAL for the ATSAM4 microcontrollers"
 keywords = ["arm", "cortex-m", "atsam4", "hal"]
 categories = ["embedded", "hardware-support", "no-std"]
@@ -10,60 +10,54 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/atsam4-rs/atsam4-hal"
 
 [dependencies]
-cast = { version = "0.2.2", default-features = false }
-cortex-m = "0.7.3"
+cast = { version = "0.3.0", default-features = false }
+cortex-m = "0.7.5"
 defmt = "0.3"
-embedded-dma = "0.1.2"
-embedded-hal = { version = "0.2.6", features = ["unproven"] }
-embedded-storage = "0.2.0"
-embedded-time = "0.10.1"
-nb = "0.1.0"
+embedded-dma = "0.2.0"
+embedded-hal = { version = "0.2.7", features = ["unproven"] }
+embedded-storage = "0.3.0"
+embedded-time = "0.12.1"
+fugit = "0.3.5"
+fugit-timer = "0.1.3"
+nb = "1.0.0"
 paste = "1.0"
 usb-device = { git = "https://github.com/haata/usb-device.git", optional = true }
 #usb-device = { version = "0.2", optional = true }
 void = { version = "1.0.2", default-features = false }
-volatile = "0.4.1"
+volatile = "0.4.5"
 
 # atsam4e
-atsam4e8c-pac = { version = "0.2.0", optional = true }
-atsam4e8e-pac = { version = "0.2.0", optional = true }
-atsam4e16c-pac = { version = "0.2.0", optional = true }
-atsam4e16e-pac = { version = "0.2.0", optional = true }
+atsam4e8c-pac = { version = "0.2.1", optional = true }
+atsam4e8e-pac = { version = "0.2.1", optional = true }
+atsam4e16c-pac = { version = "0.2.1", optional = true }
+atsam4e16e-pac = { version = "0.2.1", optional = true }
 
 # atsam4n
-atsam4n8a-pac = { version = "0.2.0", optional = true }
-atsam4n8b-pac = { version = "0.2.0", optional = true }
-atsam4n8c-pac = { version = "0.2.0", optional = true }
-atsam4n16b-pac = { version = "0.2.0", optional = true }
-atsam4n16c-pac = { version = "0.2.0", optional = true }
+atsam4n8a-pac = { version = "0.2.1", optional = true }
+atsam4n8b-pac = { version = "0.2.1", optional = true }
+atsam4n8c-pac = { version = "0.2.1", optional = true }
+atsam4n16b-pac = { version = "0.2.1", optional = true }
+atsam4n16c-pac = { version = "0.2.1", optional = true }
 
 # atsam4s
-atsam4s2a-pac = { version = "0.2.0", optional = true }
-atsam4s2b-pac = { version = "0.2.0", optional = true }
-atsam4s2c-pac = { version = "0.2.0", optional = true }
-atsam4s4a-pac = { version = "0.2.0", optional = true }
-atsam4s4b-pac = { version = "0.2.0", optional = true }
-atsam4s4c-pac = { version = "0.2.0", optional = true }
-atsam4s8b-pac = { version = "0.2.0", optional = true }
-atsam4s8c-pac = { version = "0.2.0", optional = true }
-atsam4sa16b-pac = { version = "0.2.0", optional = true }
-atsam4sa16c-pac = { version = "0.2.0", optional = true }
-atsam4sd16b-pac = { version = "0.2.0", optional = true }
-atsam4sd16c-pac = { version = "0.2.0", optional = true }
-atsam4sd32b-pac = { version = "0.2.0", optional = true }
-atsam4sd32c-pac = { version = "0.2.0", optional = true }
+atsam4s2a-pac = { version = "0.2.1", optional = true }
+atsam4s2b-pac = { version = "0.2.1", optional = true }
+atsam4s2c-pac = { version = "0.2.1", optional = true }
+atsam4s4a-pac = { version = "0.2.1", optional = true }
+atsam4s4b-pac = { version = "0.2.1", optional = true }
+atsam4s4c-pac = { version = "0.2.1", optional = true }
+atsam4s8b-pac = { version = "0.2.1", optional = true }
+atsam4s8c-pac = { version = "0.2.1", optional = true }
+atsam4sa16b-pac = { version = "0.2.1", optional = true }
+atsam4sa16c-pac = { version = "0.2.1", optional = true }
+atsam4sd16b-pac = { version = "0.2.1", optional = true }
+atsam4sd16c-pac = { version = "0.2.1", optional = true }
+atsam4sd32b-pac = { version = "0.2.1", optional = true }
+atsam4sd32c-pac = { version = "0.2.1", optional = true }
 
 [features]
 default = ["atsam4e16e"]
 unstable = []
-
-# Defmt logging disabled by default
-defmt-default = []
-defmt-trace = []
-defmt-debug = []
-defmt-info = []
-defmt-warn = []
-defmt-error = []
 
 # Enable USB clock support
 usb = ["usb-device"]

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -23,7 +23,7 @@ use crate::pdc::*;
 use core::marker::PhantomData;
 use core::sync::atomic::{compiler_fence, Ordering};
 use cortex_m::singleton;
-use embedded_dma::StaticWriteBuffer;
+use embedded_dma::WriteBuffer;
 use embedded_time::rate::Hertz;
 
 #[derive(PartialEq, Eq, Copy, Clone, Debug, defmt::Format)]
@@ -1060,13 +1060,13 @@ impl<MODE> Receive for AdcDma<MODE> {
 impl<B, MODE> ReadDma<B, u16> for AdcDma<MODE>
 where
     Self: TransferPayload,
-    B: StaticWriteBuffer<Word = u16>,
+    B: WriteBuffer<Word = u16>,
 {
     /// Assigns the buffer, enables PDC and starts ADC conversion
     fn read(mut self, mut buffer: B) -> Transfer<W, B, Self> {
         // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
         // until the end of the transfer.
-        let (ptr, len) = unsafe { buffer.static_write_buffer() };
+        let (ptr, len) = unsafe { buffer.write_buffer() };
         self.payload.adc.set_receive_address(ptr as u32);
         self.payload.adc.set_receive_counter(len as u16);
 
@@ -1080,7 +1080,7 @@ where
 impl<B, MODE> ReadDmaPaused<B, u16> for AdcDma<MODE>
 where
     Self: TransferPayload,
-    B: StaticWriteBuffer<Word = u16>,
+    B: WriteBuffer<Word = u16>,
 {
     /// Assigns the buffer, prepares PDC but does not enable the PDC
     /// Useful when there is strict timing on when the ADC conversion should start
@@ -1089,7 +1089,7 @@ where
     fn read_paused(mut self, mut buffer: B) -> Transfer<W, B, Self> {
         // NOTE(unsafe) We own the buffer now and we won't call other `&mut` on it
         // until the end of the transfer.
-        let (ptr, len) = unsafe { buffer.static_write_buffer() };
+        let (ptr, len) = unsafe { buffer.write_buffer() };
         self.payload.adc.set_receive_address(ptr as u32);
         self.payload.adc.set_receive_counter(len as u16);
 

--- a/src/efc.rs
+++ b/src/efc.rs
@@ -19,7 +19,9 @@ use crate::pac::EFC0 as EFC;
 use crate::pac::EFC1;
 
 use cortex_m::interrupt;
-use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
+use embedded_storage::nor_flash::{
+    ErrorType, NorFlash, NorFlashError, NorFlashErrorKind, ReadNorFlash,
+};
 
 // Common EEFC constants for sam4-hal
 const FLASH_PAGE_SIZE: u32 = 512;
@@ -678,9 +680,11 @@ impl Efc {
     }
 }
 
-impl ReadNorFlash for Efc {
+impl ErrorType for Efc {
     type Error = EfcError;
+}
 
+impl ReadNorFlash for Efc {
     const READ_SIZE: usize = FLASH_READ_SIZE as usize;
 
     /// Reads from atsam4 internal flash
@@ -896,4 +900,22 @@ pub enum EfcError {
     NotWithinFlashPageBoundsError,
     /// Invalid flash bank
     InvalidFlashBank,
+}
+
+impl NorFlashError for EfcError {
+    fn kind(&self) -> NorFlashErrorKind {
+        match self {
+            EfcError::AddressBoundsError => NorFlashErrorKind::OutOfBounds,
+            EfcError::CommandError => NorFlashErrorKind::Other,
+            EfcError::FlashError => NorFlashErrorKind::Other,
+            EfcError::InvalidBufferSizeError => NorFlashErrorKind::Other,
+            EfcError::InvalidFlashBank => NorFlashErrorKind::Other,
+            EfcError::InvalidGpnvmBitError => NorFlashErrorKind::Other,
+            EfcError::InvalidUserSignatureSizeError => NorFlashErrorKind::Other,
+            EfcError::LockError => NorFlashErrorKind::Other,
+            EfcError::NotWithinFlashPageBoundsError => NorFlashErrorKind::Other,
+            EfcError::Unaligned => NorFlashErrorKind::NotAligned,
+            EfcError::UnsupportedCommandError => NorFlashErrorKind::Other,
+        }
+    }
 }

--- a/src/pdc.rs
+++ b/src/pdc.rs
@@ -1,13 +1,11 @@
 //! PDC Traits for use with PDC-enabled peripherals
 //!
 //! Common interface to use with PDC enabled peripherals
-//!
-//! TODO: Currently only implements Rx mode (e.g. Adc)
 
 use core::marker::PhantomData;
 use core::sync::atomic::{self, compiler_fence, Ordering};
 use core::{mem, ptr};
-use embedded_dma::{StaticReadBuffer, StaticWriteBuffer};
+use embedded_dma::{ReadBuffer, WriteBuffer};
 
 /// Read transfer
 pub struct R;
@@ -41,7 +39,7 @@ pub trait Transmit {
 /// Trait for DMA readings from peripheral to memory.
 pub trait ReadDma<B, RS>: Receive
 where
-    B: StaticWriteBuffer<Word = RS>,
+    B: WriteBuffer<Word = RS>,
     Self: core::marker::Sized + TransferPayload,
 {
     fn read(self, buffer: B) -> Transfer<W, B, Self>;
@@ -50,7 +48,7 @@ where
 /// Trait for DMA readings from peripheral to memory, start paused.
 pub trait ReadDmaPaused<B, RS>: Receive
 where
-    B: StaticWriteBuffer<Word = RS>,
+    B: WriteBuffer<Word = RS>,
     Self: core::marker::Sized + TransferPayload,
 {
     fn read_paused(self, buffer: B) -> Transfer<W, B, Self>;
@@ -59,7 +57,7 @@ where
 /// Trait for DMA writing from memory to peripheral.
 pub trait WriteDma<B, TS>: Transmit
 where
-    B: StaticReadBuffer<Word = TS>,
+    B: ReadBuffer<Word = TS>,
     Self: core::marker::Sized + TransferPayload,
 {
     fn write(self, buffer: B) -> Transfer<R, B, Self>;
@@ -68,8 +66,8 @@ where
 /// Trait for DMA simultaneously reading and writing within one synchronous operation. Panics if both buffers are not of equal length.
 pub trait ReadWriteDma<RXB, TXB, TS>: Transmit + Receive
 where
-    RXB: StaticWriteBuffer<Word = TS>,
-    TXB: StaticReadBuffer<Word = TS>,
+    RXB: WriteBuffer<Word = TS>,
+    TXB: ReadBuffer<Word = TS>,
     Self: core::marker::Sized + TransferPayload,
 {
     fn read_write(self, rx_buffer: RXB, tx_buffer: TXB) -> Transfer<W, (RXB, TXB), Self>;
@@ -79,8 +77,8 @@ where
 /// Panics if the buffer(s) are too small
 pub trait ReadWriteDmaLen<RXB, TXB, TS>: Transmit + Receive
 where
-    RXB: StaticWriteBuffer<Word = TS>,
-    TXB: StaticReadBuffer<Word = TS>,
+    RXB: WriteBuffer<Word = TS>,
+    TXB: ReadBuffer<Word = TS>,
     Self: core::marker::Sized + TransferPayload,
 {
     fn read_write_len(

--- a/src/rtt.rs
+++ b/src/rtt.rs
@@ -51,8 +51,8 @@ impl CountDown for RealTimeTimer {
         };
 
         // Determine alarm value
-        let timeout: u32 = *timeout.into().integer();
-        let period: u32 = *period.integer();
+        let timeout: u32 = timeout.into().integer();
+        let period: u32 = period.integer();
         let alarmv = timeout / period;
 
         // ALMIEN must be disabled when setting a new alarm value

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -1,6 +1,7 @@
 use crate::hal::timer::{CountDown, Periodic};
 use crate::BorrowUnchecked;
 use core::marker::PhantomData;
+use cortex_m::{interrupt, peripheral::DWT};
 use embedded_time::duration::*;
 use embedded_time::rate::*;
 use void::Void;
@@ -264,4 +265,69 @@ tc! {
 #[cfg(feature = "atsam4e_e")]
 tc! {
     TimerCounter2: (TC2, Tc2Clock),
+}
+
+// Adapted from https://github.com/BlackbirdHQ/atat/blob/master/atat/examples/common/timer.rs
+pub struct DwtTimer<const TIMER_HZ: u32> {
+    end_time: Option<fugit::TimerInstantU32<TIMER_HZ>>,
+}
+
+impl<const TIMER_HZ: u32> DwtTimer<TIMER_HZ> {
+    pub fn new() -> Self {
+        Self { end_time: None }
+    }
+
+    pub fn now() -> u64 {
+        static mut DWT_OVERFLOWS: u32 = 0;
+        static mut OLD_DWT: u32 = 0;
+
+        interrupt::free(|_| {
+            // Safety: These static mut variables are accessed in an interrupt free section.
+            let (overflows, last_cnt) = unsafe { (&mut DWT_OVERFLOWS, &mut OLD_DWT) };
+
+            let cyccnt = DWT::cycle_count();
+
+            if cyccnt <= *last_cnt {
+                *overflows += 1;
+            }
+
+            let ticks = (*overflows as u64) << 32 | (cyccnt as u64);
+            *last_cnt = cyccnt;
+
+            ticks
+        })
+    }
+}
+
+impl<const TIMER_HZ: u32> Default for DwtTimer<TIMER_HZ> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const TIMER_HZ: u32> fugit_timer::Timer<TIMER_HZ> for DwtTimer<TIMER_HZ> {
+    type Error = core::convert::Infallible;
+
+    fn now(&mut self) -> fugit::TimerInstantU32<TIMER_HZ> {
+        fugit::TimerInstantU32::from_ticks(Self::now() as u32)
+    }
+
+    fn start(&mut self, duration: fugit::TimerDurationU32<TIMER_HZ>) -> Result<(), Self::Error> {
+        let end = self.now() + duration;
+        self.end_time.replace(end);
+        Ok(())
+    }
+
+    fn cancel(&mut self) -> Result<(), Self::Error> {
+        self.end_time.take();
+        Ok(())
+    }
+
+    fn wait(&mut self) -> nb::Result<(), Self::Error> {
+        let now = self.now();
+        match self.end_time {
+            Some(end) if end <= now => Ok(()),
+            _ => Err(nb::Error::WouldBlock),
+        }
+    }
 }


### PR DESCRIPTION
- Add DwtTimer for use with rtic
  * Useful for defmt timestamps
  * Requires fugit and fugit-timer
- Update dependencies
  * cast -> 0.3.0
  * cortex-m -> 0.7.5
  * embedded-dma -> 0.2.0
  * embedded-hal -> 0.2.7
  * embedded-storage -> 0.3.0
  * embedded-time -> 0.12.1
  * nb -> 1.0.0
  * volatile -> 0.4.5
  * pac crates -> 0.2.1
- Remove deprecated defmt- features (no longer used as of defmt 0.3)
- Fix embedded-storage api
- Fix embedded-dma api
- Updated edition to 2021
- Increment version